### PR TITLE
c6i instance family Instance type support

### DIFF
--- a/templates/swvsan-entrypoint-existing-vpc.template.yaml
+++ b/templates/swvsan-entrypoint-existing-vpc.template.yaml
@@ -132,6 +132,14 @@ Parameters:
     Type: String
   WorkloadInstanceType:
     AllowedValues:
+    - c6i.12xlarge
+    - c6i.16xlarge
+    - c6i.24xlarge
+    - c6i.32xlarge
+    - c6i.2xlarge
+    - c6i.4xlarge
+    - c6i.8xlarge
+    - c6i.metal
     - c5.12xlarge
     - c5.18xlarge
     - c5.24xlarge

--- a/templates/swvsan-entrypoint-existing-vpc.template.yaml
+++ b/templates/swvsan-entrypoint-existing-vpc.template.yaml
@@ -140,6 +140,11 @@ Parameters:
     - c6i.4xlarge
     - c6i.8xlarge
     - c6i.metal
+    - c6id.16xlarge
+    - c6id.32xlarge
+    - c6id.2xlarge
+    - c6id.4xlarge
+    - c6id.8xlarge
     - c5.12xlarge
     - c5.18xlarge
     - c5.24xlarge


### PR DESCRIPTION
*Description of changes:*
Added instances types per announcements at:
1. https://aws.amazon.com/blogs/aws/new-aws-outposts-servers-in-two-form-factors/
2. https://aws.amazon.com/ec2/instance-types/c6i/ 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
